### PR TITLE
Docs in Repo statt im Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 PHP Youthweb API ist ein objektorientierter Wrapper in PHP 5.4+ für die [Youthweb API](https://github.com/youthweb/youthweb-api).
 
-Unterstütze API Version: [0.2](https://github.com/youthweb/youthweb-api/releases/tag/0.2)
+Unterstütze API Version: 0.2.*
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ Unterstütze API Version: [0.2](https://github.com/youthweb/youthweb-api/release
 
 ## Installation
 
-### Composer
+### Composer (empfohlen)
 
 ```
 $ php composer.phar require youthweb/php-youthweb-api
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
 ```
 
 ### Manuell
@@ -25,27 +31,21 @@ Dieser Library liegt ein kleiner Autoloader bei, der verwendet werden kann.
 <?php
 
 require 'vendor/php-youthweb-api/src/autoload.php';
-
-$client = new Youthweb\Api\Client();
 ```
 
 Ansonsten funktioniert auch jeder andere [PSR-4](http://www.php-fig.org/psr/psr-4/) Autoloader.
 
-## Benutzung
+## [Dokumentation](docs/README.md) / Anwendung
 
 ```php
-<?php
-
-require_once 'src/autoload.php';
-
 $client = new \Youthweb\Api\Client();
 ```
 
 Weitere Informationen zur Anwendung gibt es in der [Dokumentation](docs/README.md).
 
-## [Changelog](https://github.com/youthweb/php-youthweb-api/blob/master/CHANGELOG.md)
+## [Changelog](CHANGELOG.md)
 
-Der Changelog ist [hier](https://github.com/youthweb/php-youthweb-api/blob/master/CHANGELOG.md) zu finden und folgt den Empfehlungen von [keepachangelog.com](http://keepachangelog.com/).
+Der Changelog ist [hier](CHANGELOG.md) zu finden und folgt den Empfehlungen von [keepachangelog.com](http://keepachangelog.com/).
 
 ## Todo
 

--- a/README.md
+++ b/README.md
@@ -39,19 +39,9 @@ Ansonsten funktioniert auch jeder andere [PSR-4](http://www.php-fig.org/psr/psr-
 require_once 'src/autoload.php';
 
 $client = new \Youthweb\Api\Client();
-
-$account = $client->getResource('account');
-
-var_dump($account->stats());
 ```
 
-Response:
-
-```
-array (size=2)
-  'user_total' => int 5727
-  'user_online' => int 39
-```
+Weitere Informationen zur Anwendung gibt es in der [Dokumentation](docs/README.md).
 
 ## [Changelog](https://github.com/youthweb/php-youthweb-api/blob/master/CHANGELOG.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+Navigation
+==========
+
+APIs:
+* [Stats](stats.md)

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -9,7 +9,7 @@ Lädt statistische Daten. Umfasst die [Youthweb Stats API](http://docs.youthweb.
 $account_stats = $client->getResource('stats')->show('account');
 ```
 
-Liefert ein `StdObject` mit den Daten als JSON API.
+Liefert ein `stdClass` mit den Daten als JSON API.
 
 ### Lädt Statistiken zum Forum
 
@@ -17,7 +17,7 @@ Liefert ein `StdObject` mit den Daten als JSON API.
 $account_stats = $client->getResource('stats')->show('forum');
 ```
 
-Liefert ein `StdObject` mit den Daten als JSON API.
+Liefert ein `stdClass` mit den Daten als JSON API.
 
 ### Lädt Statistiken zu den Gruppen
 
@@ -25,4 +25,4 @@ Liefert ein `StdObject` mit den Daten als JSON API.
 $account_stats = $client->getResource('stats')->show('groups');
 ```
 
-Liefert ein `StdObject` mit den Daten als JSON API.
+Liefert ein `stdClass` mit den Daten als JSON API.

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -1,0 +1,28 @@
+## Stats API
+[Zurück zur Navigation](README.md)
+
+Lädt statistische Daten. Umfasst die [Youthweb Stats API](http://docs.youthweb.apiary.io/reference/stats).
+
+### Lädt Statistiken zu den Accounts
+
+```php
+$account_stats = $client->getResource('stats')->show('account');
+```
+
+Liefert ein `StdObject` mit den Daten als JSON API.
+
+### Lädt Statistiken zum Forum
+
+```php
+$account_stats = $client->getResource('stats')->show('forum');
+```
+
+Liefert ein `StdObject` mit den Daten als JSON API.
+
+### Lädt Statistiken zu den Gruppen
+
+```php
+$account_stats = $client->getResource('stats')->show('groups');
+```
+
+Liefert ein `StdObject` mit den Daten als JSON API.


### PR DESCRIPTION
Ich denke, dass die Dokumentation im Repo besser aufgehoben ist als im Wiki. So fällt es leichter, neue Features zu dokumentieren.

Ersatz für #3, diesmal auf den richtigen Branch.
