### PR TITLE
Move Authenticator to own namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New interface `Youthweb\Api\Authentication\Authenticator` was added.
+- New class  `Youthweb\Api\Authentication\NativeAuthenticator` was added.
 - Add tests for PHP 8.1, 8.2 and 8.3
 - Add static code analyze with PHPStan
 
@@ -19,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Declare strict_types=1 in all PHP files
 - Move CI tests from Travis-CI to Github Actions
 - Move code coverage from Coveralls to Codecov.io
+
+### Removed
+
+- **BREAKING:** The interface `Youthweb\Api\AuthenticatorInterface` was removed, use `Youthweb\Api\Authentication\Authenticator` instead.
+- **BREAKING:** The class `Youthweb\Api\YouthwebAuthenticator` was removed, use `Youthweb\Api\Authentication\NativeAuthenticator` instead.
 
 ## [0.10.0](https://github.com/youthweb/php-youthweb-api/compare/0.9.0...0.10.0) - 2021-03-05
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "sort-packages": true
     },
     "scripts": {
-        "cs": "vendor/bin/php-cs-fixer fix",
+        "cs": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
         "phpstan": "vendor/bin/phpstan --configuration=\".phpstan.neon\" analyze",
         "test": "vendor/bin/phpunit"
     }

--- a/src/Authentication/Authenticator.php
+++ b/src/Authentication/Authenticator.php
@@ -19,44 +19,30 @@ declare(strict_types=1);
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace Youthweb\Api;
+namespace Youthweb\Api\Authentication;
 
 use InvalidArgumentException;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 use Youthweb\Api\Exception\UnauthorizedException;
 
 /**
  * Interface for authenticator
  */
-interface AuthenticatorInterface
+interface Authenticator
 {
-    /**
-     * Constructs the Authenticator
-     *
-     * @param array $options       an array of options to set on the client.
-     *                             Options include `api_version`, `api_domain`, `auth_domain`,
-     *                             `cache_namespace`, `client_id`, `client_secret` and `redirect_url`
-     * @param array $collaborators An array of collaborators that may be used to
-     *                             override this provider's default behavior. Collaborators include
-     *                             http_client`, `oauth2_provider`, `cache_provider`, `request_factory`
-     *                             and `resource_factory`.
-     */
-    public function __construct(array $options = [], array $collaborators = []);
-
     /**
      * get the authorization url
      *
      * @param array $options
-     *
-     * @return string
      */
-    public function getAuthorizationUrl(array $options = []);
+    public function getAuthorizationUrl(array $options = []): string;
 
     /**
      * get a random state
      *
-     * @return string
+     * @return string Could be empty
      */
-    public function getState();
+    public function getState(): string;
 
     /**
      * Get an access token
@@ -71,5 +57,5 @@ interface AuthenticatorInterface
      * @throws InvalidArgumentException If a wrong state was set
      * @throws UnauthorizedException    contains the url to get an authorization code
      */
-    public function getAccessToken(string $grant, array $params = []);
+    public function getAccessToken(string $grant, array $params = []): AccessTokenInterface;
 }

--- a/src/Authentication/Authenticator.php
+++ b/src/Authentication/Authenticator.php
@@ -55,7 +55,6 @@ interface Authenticator
      *                       ]
      *
      * @throws InvalidArgumentException If a wrong state was set
-     * @throws UnauthorizedException    contains the url to get an authorization code
      */
     public function getAccessToken(string $grant, array $params = []): AccessTokenInterface;
 }

--- a/src/Authentication/NativeAuthenticator.php
+++ b/src/Authentication/NativeAuthenticator.php
@@ -28,7 +28,7 @@ use League\OAuth2\Client\Token\AccessTokenInterface;
 /**
  * Native authenticator based on a league/oauth2-client provider
  */
-class NativeAuthenticator implements Authenticator
+final class NativeAuthenticator implements Authenticator
 {
     public function __construct(
         private AbstractProvider $oauth2Provider

--- a/src/Authentication/NativeAuthenticator.php
+++ b/src/Authentication/NativeAuthenticator.php
@@ -24,10 +24,9 @@ namespace Youthweb\Api\Authentication;
 use InvalidArgumentException;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Token\AccessTokenInterface;
-use Youthweb\OAuth2\Client\Provider\Youthweb as Oauth2Provider;
 
 /**
- * Interface for authenticator
+ * Native authenticator based on a league/oauth2-client provider
  */
 class NativeAuthenticator implements Authenticator
 {

--- a/src/Authentication/NativeAuthenticator.php
+++ b/src/Authentication/NativeAuthenticator.php
@@ -19,70 +19,50 @@ declare(strict_types=1);
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace Youthweb\Api;
+namespace Youthweb\Api\Authentication;
 
 use InvalidArgumentException;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 use Youthweb\OAuth2\Client\Provider\Youthweb as Oauth2Provider;
 
 /**
  * Interface for authenticator
  */
-class YouthwebAuthenticator implements AuthenticatorInterface
+class NativeAuthenticator implements Authenticator
 {
-    /**
-     * @var string
-     */
-    private $api_version = '0.15';
+    private string $apiVersion = '0.20';
 
-    /**
-     * @var string
-     */
-    private $api_domain = 'https://api.youthweb.net';
+    private string $apiDomain = 'https://api.youthweb.net';
 
-    /**
-     * @var string
-     */
-    private $auth_domain = 'https://youthweb.net';
+    private string $authDomain = 'https://youthweb.net';
 
-    /**
-     * @var string
-     */
-    private $client_id;
+    private string $clientId = '';
 
-    /**
-     * @var string
-     */
-    private $client_secret;
+    private string $clientSecret = '';
 
-    /**
-     * @var string
-     */
-    private $redirect_url = '';
+    private string $redirectUrl = '';
 
-    /**
-     * @var Oauth2Provider
-     */
-    private $oauth2_provider;
+    private Oauth2Provider $oauth2Provider;
 
     /**
      * Constructs the Authenticator
      *
      * @param array $options       an array of options to set on the client.
-     *                             Options include `api_domain`, `auth_domain`, `client_id`,
-     *                             `client_secret` and `redirect_url`
+     *                             Options include `apiDomain`, `authDomain`, `clientId`,
+     *                             `clientSecret` and `redirectUrl`
      * @param array $collaborators An array of collaborators that may be used to
      *                             override this provider's default behavior. Collaborators include
-     *                             `oauth2_provider`.
+     *                             `oauth2Provider`.
      */
     public function __construct(array $options = [], array $collaborators = [])
     {
         $allowed_options = [
-            'api_version',
-            'api_domain',
-            'auth_domain',
-            'client_id',
-            'client_secret',
-            'redirect_url',
+            'apiVersion',
+            'apiDomain',
+            'authDomain',
+            'clientId',
+            'clientSecret',
+            'redirectUrl',
         ];
 
         foreach ($options as $option => $value) {
@@ -93,28 +73,26 @@ class YouthwebAuthenticator implements AuthenticatorInterface
             }
         }
 
-        if (empty($collaborators['oauth2_provider'])) {
-            $collaborators['oauth2_provider'] = new Oauth2Provider([
-                'clientId'     => $this->client_id,
-                'clientSecret' => $this->client_secret,
-                'redirectUri'  => $this->redirect_url,
-                'apiVersion'   => $this->api_version,
-                'apiDomain'    => $this->api_domain,
-                'domain'       => $this->auth_domain,
+        if (empty($collaborators['oauth2Provider'])) {
+            $collaborators['oauth2Provider'] = new Oauth2Provider([
+                'clientId'     => $this->clientId,
+                'clientSecret' => $this->clientSecret,
+                'redirectUri'  => $this->redirectUrl,
+                'apiVersion'   => $this->apiVersion,
+                'apiDomain'    => $this->apiDomain,
+                'domain'       => $this->authDomain,
             ]);
         }
 
-        $this->setOauth2Provider($collaborators['oauth2_provider']);
+        $this->setOauth2Provider($collaborators['oauth2Provider']);
     }
 
     /**
      * get the authorization url
      *
      * @param array $options
-     *
-     * @return string
      */
-    public function getAuthorizationUrl(array $options = [])
+    public function getAuthorizationUrl(array $options = []): string
     {
         return $this->getOauth2Provider()->getAuthorizationUrl($options);
     }
@@ -122,9 +100,9 @@ class YouthwebAuthenticator implements AuthenticatorInterface
     /**
      * get a random state
      *
-     * @return string
+     * @return string Could be empty
      */
-    public function getState()
+    public function getState(): string
     {
         $state = $this->getOauth2Provider()->getState();
 
@@ -152,7 +130,7 @@ class YouthwebAuthenticator implements AuthenticatorInterface
      *
      * @throws InvalidArgumentException If a wrong state or grant was set
      */
-    public function getAccessToken(string $grant, array $params = [])
+    public function getAccessToken(string $grant, array $params = []): AccessTokenInterface
     {
         $allowed_grants = [
             'authorization_code',
@@ -168,11 +146,11 @@ class YouthwebAuthenticator implements AuthenticatorInterface
     /**
      * Set a oauth2 provider
      *
-     * @param Oauth2Provider $oauth2_provider the oauth2 provider
+     * @param Oauth2Provider $oauth2Provider the oauth2 provider
      */
-    private function setOauth2Provider(Oauth2Provider $oauth2_provider): void
+    private function setOauth2Provider(Oauth2Provider $oauth2Provider): void
     {
-        $this->oauth2_provider = $oauth2_provider;
+        $this->oauth2Provider = $oauth2Provider;
     }
 
     /**
@@ -182,6 +160,6 @@ class YouthwebAuthenticator implements AuthenticatorInterface
      */
     private function getOauth2Provider(): Oauth2Provider
     {
-        return $this->oauth2_provider;
+        return $this->oauth2Provider;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -38,6 +38,7 @@ use Youthweb\Api\Authentication\Authenticator;
 use Youthweb\Api\Authentication\NativeAuthenticator;
 use Youthweb\Api\Exception\UnauthorizedException;
 use Youthweb\Api\Resource\ResourceInterface;
+use Youthweb\OAuth2\Client\Provider\Youthweb as Oauth2Provider;
 
 /**
  * Simple PHP Youthweb client
@@ -173,14 +174,14 @@ final class Client implements ClientInterface
         $this->setHttpClientInternally($collaborators['http_client']);
 
         if (empty($collaborators['oauth2_provider'])) {
-            $collaborators['oauth2_provider'] = new NativeAuthenticator([
+            $collaborators['oauth2_provider'] = new NativeAuthenticator(new Oauth2Provider([
                 'clientId'     => $this->client_id,
                 'clientSecret' => $this->client_secret,
                 'redirectUrl'  => $this->redirect_url,
                 'apiVersion'   => $this->api_version,
                 'apiDomain'    => $this->api_domain,
                 'authDomain'   => $this->auth_domain,
-            ]);
+            ]));
         }
 
         $this->setOauth2Provider($collaborators['oauth2_provider']);

--- a/src/Client.php
+++ b/src/Client.php
@@ -28,12 +28,14 @@ use DateTime;
 use Exception;
 use GuzzleHttp\Exception\ClientException;
 use InvalidArgumentException;
-use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
+use Youthweb\Api\Authentication\Authenticator;
+use Youthweb\Api\Authentication\NativeAuthenticator;
 use Youthweb\Api\Exception\UnauthorizedException;
 use Youthweb\Api\Resource\ResourceInterface;
 
@@ -72,7 +74,7 @@ final class Client implements ClientInterface
     private $http_client;
 
     /**
-     * @var AuthenticatorInterface
+     * @var Authenticator
      */
     private $oauth2_provider;
 
@@ -171,13 +173,13 @@ final class Client implements ClientInterface
         $this->setHttpClientInternally($collaborators['http_client']);
 
         if (empty($collaborators['oauth2_provider'])) {
-            $collaborators['oauth2_provider'] = new YouthwebAuthenticator([
-                'client_id'     => $this->client_id,
-                'client_secret' => $this->client_secret,
-                'redirect_url'  => $this->redirect_url,
-                'api_version'   => $this->api_version,
-                'api_domain'    => $this->api_domain,
-                'auth_domain'   => $this->auth_domain,
+            $collaborators['oauth2_provider'] = new NativeAuthenticator([
+                'clientId'     => $this->client_id,
+                'clientSecret' => $this->client_secret,
+                'redirectUrl'  => $this->redirect_url,
+                'apiVersion'   => $this->api_version,
+                'apiDomain'    => $this->api_domain,
+                'authDomain'   => $this->auth_domain,
             ]);
         }
 
@@ -470,10 +472,8 @@ final class Client implements ClientInterface
 
     /**
      * Save a access token in cache provider
-     *
-     * @param AccessToken $token The access token
      */
-    private function saveAccessToken(AccessToken $token): void
+    private function saveAccessToken(AccessTokenInterface $token): void
     {
         $access_token_item = $this->getCacheItem(self::CACHEKEY_ACCESS_TOKEN);
         $access_token_item->set($token->getToken());
@@ -484,9 +484,9 @@ final class Client implements ClientInterface
     /**
      * Set a oauth2 provider
      *
-     * @param AuthenticatorInterface $oauth2_provider the oauth2 provider
+     * @param Authenticator $oauth2_provider the oauth2 provider
      */
-    private function setOauth2Provider(AuthenticatorInterface $oauth2_provider): void
+    private function setOauth2Provider(Authenticator $oauth2_provider): void
     {
         $this->oauth2_provider = $oauth2_provider;
     }
@@ -494,9 +494,9 @@ final class Client implements ClientInterface
     /**
      * Get the oauth2 provider
      *
-     * @return AuthenticatorInterface the oauth2 provider
+     * @return Authenticator the oauth2 provider
      */
-    private function getOauth2Provider()
+    private function getOauth2Provider(): Authenticator
     {
         return $this->oauth2_provider;
     }

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -21,9 +21,20 @@ declare(strict_types=1);
 
 namespace Youthweb\Api\Tests\Unit;
 
-use Youthweb\Api\Client;
 use InvalidArgumentException;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Youthweb\Api\Authentication\Authenticator;
+use Youthweb\Api\Client;
+use Youthweb\Api\HttpClientInterface;
+use Youthweb\Api\RequestFactoryInterface;
+use Youthweb\Api\Resource\UsersInterface;
+use Youthweb\Api\ResourceFactoryInterface;
 
 class ClientTest extends TestCase
 {
@@ -37,11 +48,11 @@ class ClientTest extends TestCase
         $options = array_merge($default_options, $options);
 
         $default_collaborators = [
-            'http_client' => $this->createMock('Youthweb\Api\HttpClientInterface'),
-            'oauth2_provider' => $this->createMock('Youthweb\Api\AuthenticatorInterface'),
-            'cache_provider' => $this->createMock('Psr\Cache\CacheItemPoolInterface'),
-            'request_factory' => $this->createMock('Youthweb\Api\RequestFactoryInterface'),
-            'resource_factory' => $this->createMock('Youthweb\Api\ResourceFactoryInterface'),
+            'http_client' => $this->createMock(HttpClientInterface::class),
+            'oauth2_provider' => $this->createMock(Authenticator::class),
+            'cache_provider' => $this->createMock(CacheItemPoolInterface::class),
+            'request_factory' => $this->createMock(RequestFactoryInterface::class),
+            'resource_factory' => $this->createMock(ResourceFactoryInterface::class),
         ];
 
         $collaborators = array_merge($default_collaborators, $collaborators);
@@ -54,9 +65,9 @@ class ClientTest extends TestCase
      */
     public function testGetAuthorizationUrlReturnsUrl(): void
     {
-        $oauth2_provider = $this->createMock('Youthweb\Api\AuthenticatorInterface');
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item_state = $this->createMock('Psr\Cache\CacheItemInterface');
+        $oauth2_provider = $this->createMock(Authenticator::class);
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item_state = $this->createMock(CacheItemInterface::class);
 
         $url = 'https://example.org';
 
@@ -95,9 +106,9 @@ class ClientTest extends TestCase
      */
     public function testGetStateReturnsState(): void
     {
-        $oauth2_provider = $this->createMock('Youthweb\Api\AuthenticatorInterface');
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item_state = $this->createMock('Psr\Cache\CacheItemInterface');
+        $oauth2_provider = $this->createMock(Authenticator::class);
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item_state = $this->createMock(CacheItemInterface::class);
 
         $cache_item_state->expects($this->exactly(1))
             ->method('isHit')
@@ -132,8 +143,8 @@ class ClientTest extends TestCase
      */
     public function testGetResource(): void
     {
-        $resource = $this->createMock('Youthweb\Api\Resource\UsersInterface');
-        $resource_factory = $this->createMock('Youthweb\Api\ResourceFactoryInterface');
+        $resource = $this->createMock(UsersInterface::class);
+        $resource_factory = $this->createMock(ResourceFactoryInterface::class);
 
         $resource_factory->expects($this->once())
             ->method('createResource')
@@ -156,7 +167,7 @@ class ClientTest extends TestCase
      */
     public function testGetUnknownResourceThrowsException(): void
     {
-        $resource_factory = $this->createMock('Youthweb\Api\ResourceFactoryInterface');
+        $resource_factory = $this->createMock(ResourceFactoryInterface::class);
 
         $resource_factory->expects($this->once())
             ->method('createResource')
@@ -202,12 +213,12 @@ class ClientTest extends TestCase
      */
     public function testAuthorizeWithAuthCodeSavesToken(): void
     {
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $oauth2_provider = $this->createMock('Youthweb\Api\AuthenticatorInterface');
-        $cache_item_access = $this->createMock('Psr\Cache\CacheItemInterface');
-        $cache_item_state = $this->createMock('Psr\Cache\CacheItemInterface');
-        $access_token = $this->createMock('League\OAuth2\Client\Token\AccessToken');
+        $http_client = $this->createMock(HttpClientInterface::class);
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $oauth2_provider = $this->createMock(Authenticator::class);
+        $cache_item_access = $this->createMock(CacheItemInterface::class);
+        $cache_item_state = $this->createMock(CacheItemInterface::class);
+        $access_token = $this->createMock(AccessTokenInterface::class);
 
         $access_token->expects($this->once())
             ->method('getToken')
@@ -264,12 +275,12 @@ class ClientTest extends TestCase
      */
     public function testAuthorizeWithAuthCodeAndStateSavesToken(): void
     {
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $oauth2_provider = $this->createMock('Youthweb\Api\AuthenticatorInterface');
-        $cache_item_access = $this->createMock('Psr\Cache\CacheItemInterface');
-        $cache_item_state = $this->createMock('Psr\Cache\CacheItemInterface');
-        $access_token = $this->createMock('League\OAuth2\Client\Token\AccessToken');
+        $http_client = $this->createMock(HttpClientInterface::class);
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $oauth2_provider = $this->createMock(Authenticator::class);
+        $cache_item_access = $this->createMock(CacheItemInterface::class);
+        $cache_item_state = $this->createMock(CacheItemInterface::class);
+        $access_token = $this->createMock(AccessTokenInterface::class);
 
         $access_token->expects($this->once())
             ->method('getToken')
@@ -333,9 +344,9 @@ class ClientTest extends TestCase
      */
     public function testAuthorizeWithAuthCodeAndWrongStateThrowsException(): void
     {
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item_state = $this->createMock('Psr\Cache\CacheItemInterface');
+        $http_client = $this->createMock(HttpClientInterface::class);
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item_state = $this->createMock(CacheItemInterface::class);
 
         $cache_item_state->expects($this->any())
             ->method('isHit')
@@ -380,9 +391,9 @@ class ClientTest extends TestCase
      */
     public function testIsAuthorizeReturnsTrue(): void
     {
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item_state = $this->createMock('Psr\Cache\CacheItemInterface');
+        $http_client = $this->createMock(HttpClientInterface::class);
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item_state = $this->createMock(CacheItemInterface::class);
 
         $cache_item_state->expects($this->any())
             ->method('isHit')
@@ -418,9 +429,9 @@ class ClientTest extends TestCase
      */
     public function testIsAuthorizeReturnsFalse(): void
     {
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item_state = $this->createMock('Psr\Cache\CacheItemInterface');
+        $http_client = $this->createMock(HttpClientInterface::class);
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item_state = $this->createMock(CacheItemInterface::class);
 
         $cache_item_state->expects($this->any())
             ->method('isHit')
@@ -455,13 +466,13 @@ class ClientTest extends TestCase
      */
     public function testAuthorizedGetRequestReturnsObject(): void
     {
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item_access = $this->createMock('Psr\Cache\CacheItemInterface');
-        $body = $this->createMock('Psr\Http\Message\StreamInterface');
-        $request_factory = $this->createMock('Youthweb\Api\RequestFactoryInterface');
-        $request = $this->createMock('Psr\Http\Message\RequestInterface');
-        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item_access = $this->createMock(CacheItemInterface::class);
+        $body = $this->createMock(StreamInterface::class);
+        $request_factory = $this->createMock(RequestFactoryInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $http_client = $this->createMock(HttpClientInterface::class);
 
         $cache_item_access->expects($this->once())
             ->method('isHit')
@@ -515,11 +526,11 @@ class ClientTest extends TestCase
      */
     public function testGetUnauthorizedReturnsObject(): void
     {
-        $request_factory = $this->createMock('Youthweb\Api\RequestFactoryInterface');
-        $request = $this->createMock('Psr\Http\Message\RequestInterface');
-        $body = $this->createMock('Psr\Http\Message\StreamInterface');
-        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
+        $request_factory = $this->createMock(RequestFactoryInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $body = $this->createMock(StreamInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $http_client = $this->createMock(HttpClientInterface::class);
 
         $request_factory->expects($this->once())
             ->method('createRequest')
@@ -554,11 +565,11 @@ class ClientTest extends TestCase
      */
     public function testPostUnauthorizedReturnsObject(): void
     {
-        $request_factory = $this->createMock('Youthweb\Api\RequestFactoryInterface');
-        $request = $this->createMock('Psr\Http\Message\RequestInterface');
-        $body = $this->createMock('Psr\Http\Message\StreamInterface');
-        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
+        $request_factory = $this->createMock(RequestFactoryInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $body = $this->createMock(StreamInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $http_client = $this->createMock(HttpClientInterface::class);
 
         $request_factory->expects($this->once())
             ->method('createRequest')
@@ -593,10 +604,10 @@ class ClientTest extends TestCase
      */
     public function testGetRequestWithoutCredentialsThrowsException(): void
     {
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item_access = $this->createMock('Psr\Cache\CacheItemInterface');
-        $resource_factory = $this->createMock('Youthweb\Api\ResourceFactoryInterface');
+        $http_client = $this->createMock(HttpClientInterface::class);
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item_access = $this->createMock(CacheItemInterface::class);
+        $resource_factory = $this->createMock(ResourceFactoryInterface::class);
 
         $cache_item_access->expects($this->once())
             ->method('isHit')
@@ -632,14 +643,14 @@ class ClientTest extends TestCase
      */
     public function testHandleClientExceptionWithResponseException(): void
     {
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item_access = $this->createMock('Psr\Cache\CacheItemInterface');
-        $body = $this->createMock('Psr\Http\Message\StreamInterface');
-        $request_factory = $this->createMock('Youthweb\Api\RequestFactoryInterface');
-        $request = $this->createMock('Psr\Http\Message\RequestInterface');
-        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
-        $resource_factory = $this->createMock('Youthweb\Api\ResourceFactoryInterface');
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item_access = $this->createMock(CacheItemInterface::class);
+        $body = $this->createMock(StreamInterface::class);
+        $request_factory = $this->createMock(RequestFactoryInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $http_client = $this->createMock(HttpClientInterface::class);
+        $resource_factory = $this->createMock(ResourceFactoryInterface::class);
 
         $request_factory->expects($this->once())
             ->method('createRequest')
@@ -698,14 +709,14 @@ class ClientTest extends TestCase
      */
     public function testHandleClientExceptionWithDetailResponseException(): void
     {
-        $body = $this->createMock('Psr\Http\Message\StreamInterface');
-        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item_access = $this->createMock('Psr\Cache\CacheItemInterface');
-        $request_factory = $this->createMock('Youthweb\Api\RequestFactoryInterface');
-        $request = $this->createMock('Psr\Http\Message\RequestInterface');
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
-        $resource_factory = $this->createMock('Youthweb\Api\ResourceFactoryInterface');
+        $body = $this->createMock(StreamInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item_access = $this->createMock(CacheItemInterface::class);
+        $request_factory = $this->createMock(RequestFactoryInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $http_client = $this->createMock(HttpClientInterface::class);
+        $resource_factory = $this->createMock(ResourceFactoryInterface::class);
 
         $body->expects($this->once())
             ->method('getContents')
@@ -764,9 +775,9 @@ class ClientTest extends TestCase
      */
     public function testHandleClientExceptionWithException(): void
     {
-        $http_client = $this->createMock('Youthweb\Api\HttpClientInterface');
-        $request_factory = $this->createMock('Youthweb\Api\RequestFactoryInterface');
-        $request = $this->createMock('Psr\Http\Message\RequestInterface');
+        $http_client = $this->createMock(HttpClientInterface::class);
+        $request_factory = $this->createMock(RequestFactoryInterface::class);
+        $request = $this->createMock(RequestInterface::class);
 
         $exception = new \Exception('error message', 0);
 
@@ -798,8 +809,8 @@ class ClientTest extends TestCase
      */
     public function testGetCacheItemReturnsCacheItem(): void
     {
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item = $this->createMock('Psr\Cache\CacheItemInterface');
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item = $this->createMock(CacheItemInterface::class);
 
         $cache_provider->expects($this->exactly(1))
             ->method('getItem')
@@ -822,8 +833,8 @@ class ClientTest extends TestCase
      */
     public function testSaveCacheItem(): void
     {
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item = $this->createMock('Psr\Cache\CacheItemInterface');
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item = $this->createMock(CacheItemInterface::class);
 
         $cache_provider->expects($this->exactly(1))
             ->method('saveDeferred')
@@ -847,8 +858,8 @@ class ClientTest extends TestCase
      */
     public function testDeleteCacheItem(): void
     {
-        $cache_provider = $this->createMock('Psr\Cache\CacheItemPoolInterface');
-        $cache_item = $this->createMock('Psr\Cache\CacheItemInterface');
+        $cache_provider = $this->createMock(CacheItemPoolInterface::class);
+        $cache_item = $this->createMock(CacheItemInterface::class);
 
         $cache_item->expects($this->exactly(1))
             ->method('getKey')


### PR DESCRIPTION
This PR will move the Authenticator to their own namespace and improve the return types.

This is a breaking change.