### PR TITLE
Drop support for PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['8.0', '8.1', '8.2', '8.3']
         coverage: [false]
         include:
           ## Run code coverage on highest supported PHP version.

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,8 +12,8 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PER' => true,
         '@PER:risky' => true,
-        '@PHP74Migration' => true,
-        '@PHP74Migration:risky' => true,
+        '@PHP80Migration' => true,
+        '@PHP80Migration:risky' => true,
         '@PHPUnit84Migration:risky' => true,
     ])
     ->setFinder($finder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move CI tests from Travis-CI to Github Actions
 - Move code coverage from Coveralls to Codecov.io
 
+### Removed
+
+- Drop support for PHP 7.4
+
 ## [0.10.0](https://github.com/youthweb/php-youthweb-api/compare/0.9.0...0.10.0) - 2021-03-05
 
 ### Added
@@ -29,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - default api version was set to [Youthweb-API 0.18](https://developer.youthweb.net/20210221-Youthweb-API-0.18.html)
+
+### Removed
+
 - Drop support for PHP 7.2 and 7.3
 
 ## [0.9.0](https://github.com/youthweb/php-youthweb-api/compare/0.8...0.9.0) - 2019-10-01
@@ -38,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - api version will be automatically set into Oauth2Provider
 - default api version was set to [Youthweb-API 0.15](https://developer.youthweb.net/20190908-Youthweb-API-0.15.html)
 
-### Changed
+### Removed
 
 - Drop support for PHP 5.6, 7.0 and 7.1
 
@@ -141,7 +148,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **Breaking:** Support for PHP 5.5 was dropped. Minimum requirement is now PHP 5.6.
+- Support for PHP 5.5 was dropped. Minimum requirement is now PHP 5.6.
 
 ## [0.4.0](https://github.com/youthweb/php-youthweb-api/compare/0.3...0.4) - 2016-08-01
 
@@ -163,8 +170,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **Breaking:** Drop PHP 5.4 support
 - **Breaking:** Manuel installation via `autoload.php`. Use composer instead
+- Drop support for PHP 5.4
 
 ## [0.2.0](https://github.com/youthweb/php-youthweb-api/compare/0.1...0.2) - 2015-06-21
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/youthweb/php-youthweb-api/actions/workflows/ci.yml/badge.svg?branch=v0.x)](https://github.com/youthweb/php-youthweb-api/actions)
 [![codecov](https://codecov.io/gh/youthweb/php-youthweb-api/branch/v0.x/graph/badge.svg?token=vWBAUXTFLI)](https://codecov.io/gh/youthweb/php-youthweb-api)
 
-PHP Youthweb API ist ein objektorientierter Wrapper in PHP 5.6+ für die [Youthweb API](https://github.com/youthweb/youthweb-api).
+PHP Youthweb API ist ein objektorientierter Wrapper in PHP 8.0+ für die [Youthweb API](https://github.com/youthweb/youthweb-api).
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "sort-packages": true
     },
     "scripts": {
-        "cs": "vendor/bin/php-cs-fixer fix",
+        "cs": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
         "phpstan": "vendor/bin/phpstan --configuration=\".phpstan.neon\" analyze",
         "test": "vendor/bin/phpunit"
     }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "art4/json-api-client": "^1.0",
         "cache/void-adapter": "^1.1",
         "guzzlehttp/guzzle": "^7.2",


### PR DESCRIPTION
We will drop support for PHP 7.4 so we can use new features like constructor property promotion.