### PR TITLE
Replace VoidVache with NullCacheItemPool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "require": {
         "php": "^8.0",
         "art4/json-api-client": "^1.0",
-        "cache/void-adapter": "^1.1",
         "guzzlehttp/guzzle": "^7.2",
         "psr/cache": "^2.0 || ^3.0",
         "psr/http-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "art4/json-api-client": "^1.0",
         "cache/void-adapter": "^1.1",
         "guzzlehttp/guzzle": "^7.2",
+        "psr/cache": "^2.0 || ^3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "youthweb/oauth2-youthweb": "^1.2"

--- a/src/Authentication/NativeAuthenticator.php
+++ b/src/Authentication/NativeAuthenticator.php
@@ -52,7 +52,7 @@ final class NativeAuthenticator implements Authenticator
      */
     public function getState(): string
     {
-        $state = $this->oauth2Provider->getState();
+        $state = (string) $this->oauth2Provider->getState();
 
         // Workaround, if no state was generated so far
         if ($state === '') {
@@ -60,7 +60,7 @@ final class NativeAuthenticator implements Authenticator
             $this->getAuthorizationUrl();
 
             // get the generated state
-            $state = $this->oauth2Provider->getState();
+            $state = (string) $this->oauth2Provider->getState();
         }
 
         return $state;

--- a/src/Cache/NullCacheItem.php
+++ b/src/Cache/NullCacheItem.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * PHP Youthweb API is an object-oriented wrapper for PHP of the Youthweb API.
+ * Copyright (C) 2015-2019  Youthweb e.V.  https://youthweb.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Youthweb\Api\Cache;
+
+use DateInterval;
+use DateTimeInterface;
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * This is a fake implementation of CacheItemInterface
+ */
+final class NullCacheItem implements CacheItemInterface
+{
+    private string $key;
+
+    private mixed $value;
+
+    public function __construct(string $key)
+    {
+        $this->key = $key;
+    }
+
+    /**
+     * Returns the key for the current cache item.
+     *
+     * The key is loaded by the Implementing Library, but should be available to
+     * the higher level callers when needed.
+     *
+     * @return string
+     *   The key string for this cache item.
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * Retrieves the value of the item from the cache associated with this object's key.
+     *
+     * The value returned must be identical to the value originally stored by set().
+     *
+     * If isHit() returns false, this method MUST return null. Note that null
+     * is a legitimate cached value, so the isHit() method SHOULD be used to
+     * differentiate between "null value was found" and "no value was found."
+     *
+     * @return mixed
+     *   The value corresponding to this cache item's key, or null if not found.
+     */
+    public function get(): mixed
+    {
+        if (isset($this->value)) {
+            return $this->value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Confirms if the cache item lookup resulted in a cache hit.
+     *
+     * Note: This method MUST NOT have a race condition between calling isHit()
+     * and calling get().
+     *
+     * @return bool
+     *   True if the request resulted in a cache hit. False otherwise.
+     */
+    public function isHit(): bool
+    {
+        return isset($this->value);
+    }
+
+    /**
+     * Sets the value represented by this cache item.
+     *
+     * The $value argument may be any item that can be serialized by PHP,
+     * although the method of serialization is left up to the Implementing
+     * Library.
+     *
+     * @param mixed $value
+     *   The serializable value to be stored.
+     *
+     * @return static
+     *   The invoked object.
+     */
+    public function set(mixed $value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Sets the expiration time for this cache item.
+     *
+     * @param ?DateTimeInterface $expiration
+     *   The point in time after which the item MUST be considered expired.
+     *   If null is passed explicitly, a default value MAY be used. If none is set,
+     *   the value should be stored permanently or for as long as the
+     *   implementation allows.
+     *
+     * @return static
+     *   The called object.
+     */
+    public function expiresAt(?DateTimeInterface $expiration): static
+    {
+        return $this;
+    }
+
+    /**
+     * Sets the expiration time for this cache item.
+     *
+     * @param int|DateInterval|null $time
+     *   The period of time from the present after which the item MUST be considered
+     *   expired. An integer parameter is understood to be the time in seconds until
+     *   expiration. If null is passed explicitly, a default value MAY be used.
+     *   If none is set, the value should be stored permanently or for as long as the
+     *   implementation allows.
+     *
+     * @return static
+     *   The called object.
+     */
+    public function expiresAfter(int|DateInterval|null $time): static
+    {
+        return $this;
+    }
+}

--- a/src/Cache/NullCacheItemPool.php
+++ b/src/Cache/NullCacheItemPool.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * PHP Youthweb API is an object-oriented wrapper for PHP of the Youthweb API.
+ * Copyright (C) 2015-2019  Youthweb e.V.  https://youthweb.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Youthweb\Api\Cache;
+
+use Exception;
+use InvalidArgumentException;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * This is a fake implementation of CacheItemPoolInterface
+ */
+final class NullCacheItemPool implements CacheItemPoolInterface
+{
+    /**
+     * @var CacheItemInterface[]
+     */
+    private array $items = [];
+
+    /**
+     * Returns a Cache Item representing the specified key.
+     *
+     * This method must always return a CacheItemInterface object, even in case of
+     * a cache miss. It MUST NOT return null.
+     *
+     * @param string $key
+     *   The key for which to return the corresponding Cache Item.
+     *
+     * @throws InvalidArgumentException
+     *   If the $key string is not a legal value a \Psr\Cache\InvalidArgumentException
+     *   MUST be thrown.
+     *
+     * @return CacheItemInterface
+     *   The corresponding Cache Item.
+     */
+    public function getItem(string $key): CacheItemInterface
+    {
+        if (! array_key_exists($key, $this->items)) {
+            $this->items[$key] = new NullCacheItem($key);
+        }
+
+        return $this->items[$key];
+    }
+
+    /**
+     * Returns a traversable set of cache items.
+     *
+     * @param string[] $keys
+     *   An indexed array of keys of items to retrieve.
+     *
+     * @throws InvalidArgumentException
+     *   If any of the keys in $keys are not a legal value a \Psr\Cache\InvalidArgumentException
+     *   MUST be thrown.
+     *
+     * @return array|\Traversable
+     *   A traversable collection of Cache Items keyed by the cache keys of
+     *   each item. A Cache item will be returned for each key, even if that
+     *   key is not found. However, if no keys are specified then an empty
+     *   traversable MUST be returned instead.
+     */
+    public function getItems(array $keys = []): iterable
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+
+    /**
+     * Confirms if the cache contains specified cache item.
+     *
+     * Note: This method MAY avoid retrieving the cached value for performance reasons.
+     * This could result in a race condition with CacheItemInterface::get(). To avoid
+     * such situation use CacheItemInterface::isHit() instead.
+     *
+     * @param string $key
+     *   The key for which to check existence.
+     *
+     * @throws InvalidArgumentException
+     *   If the $key string is not a legal value a \Psr\Cache\InvalidArgumentException
+     *   MUST be thrown.
+     *
+     * @return bool
+     *   True if item exists in the cache, false otherwise.
+     */
+    public function hasItem(string $key): bool
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+
+    /**
+     * Deletes all items in the pool.
+     *
+     * @return bool
+     *   True if the pool was successfully cleared. False if there was an error.
+     */
+    public function clear(): bool
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+
+    /**
+     * Removes the item from the pool.
+     *
+     * @param string $key
+     *   The key to delete.
+     *
+     * @throws InvalidArgumentException
+     *   If the $key string is not a legal value a \Psr\Cache\InvalidArgumentException
+     *   MUST be thrown.
+     *
+     * @return bool
+     *   True if the item was successfully removed. False if there was an error.
+     */
+    public function deleteItem(string $key): bool
+    {
+        if (array_key_exists($key, $this->items)) {
+            unset($this->items[$key]);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Removes multiple items from the pool.
+     *
+     * @param string[] $keys
+     *   An array of keys that should be removed from the pool.
+     *
+     * @throws InvalidArgumentException
+     *   If any of the keys in $keys are not a legal value a \Psr\Cache\InvalidArgumentException
+     *   MUST be thrown.
+     *
+     * @return bool
+     *   True if the items were successfully removed. False if there was an error.
+     */
+    public function deleteItems(array $keys): bool
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+
+    /**
+     * Persists a cache item immediately.
+     *
+     * @param CacheItemInterface $item
+     *   The cache item to save.
+     *
+     * @return bool
+     *   True if the item was successfully persisted. False if there was an error.
+     */
+    public function save(CacheItemInterface $item): bool
+    {
+        $this->items[$item->getKey()] = $item;
+
+        return true;
+    }
+
+    /**
+     * Sets a cache item to be persisted later.
+     *
+     * @param CacheItemInterface $item
+     *   The cache item to save.
+     *
+     * @return bool
+     *   False if the item could not be queued or if a commit was attempted and failed. True otherwise.
+     */
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+
+    /**
+     * Persists any deferred cache items.
+     *
+     * @return bool
+     *   True if all not-yet-saved items were successfully saved or there were none. False otherwise.
+     */
+    public function commit(): bool
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+}

--- a/src/Cache/NullCacheItemPool.php
+++ b/src/Cache/NullCacheItemPool.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 namespace Youthweb\Api\Cache;
 
 use Exception;
-use InvalidArgumentException;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
 
 /**
  * This is a fake implementation of CacheItemPoolInterface
@@ -54,6 +54,8 @@ final class NullCacheItemPool implements CacheItemPoolInterface
      */
     public function getItem(string $key): CacheItemInterface
     {
+        $this->assertValidKey($key);
+
         if (! array_key_exists($key, $this->items)) {
             $this->items[$key] = new NullCacheItem($key);
         }
@@ -130,6 +132,8 @@ final class NullCacheItemPool implements CacheItemPoolInterface
      */
     public function deleteItem(string $key): bool
     {
+        $this->assertValidKey($key);
+
         if (array_key_exists($key, $this->items)) {
             unset($this->items[$key]);
 
@@ -168,7 +172,11 @@ final class NullCacheItemPool implements CacheItemPoolInterface
      */
     public function save(CacheItemInterface $item): bool
     {
-        $this->items[$item->getKey()] = $item;
+        $key = $item->getKey();
+
+        $this->assertValidKey($key);
+
+        $this->items[$key] = $item;
 
         return true;
     }
@@ -196,5 +204,17 @@ final class NullCacheItemPool implements CacheItemPoolInterface
     public function commit(): bool
     {
         throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function assertValidKey(string $key): void
+    {
+        if ($key !== '' && ! preg_match('/[^a-zA-Z0-9_\.]/', $key)) {
+            return;
+        }
+
+        throw new class () extends Exception implements InvalidArgumentException {};
     }
 }

--- a/src/Cache/NullCacheItemPool.php
+++ b/src/Cache/NullCacheItemPool.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace Youthweb\Api\Cache;
 
 use Exception;
+use LogicException;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
@@ -172,13 +173,10 @@ final class NullCacheItemPool implements CacheItemPoolInterface
      */
     public function save(CacheItemInterface $item): bool
     {
-        $key = $item->getKey();
-
-        $this->assertValidKey($key);
-
-        $this->items[$key] = $item;
-
-        return true;
+        throw new LogicException(sprintf(
+            'A cache provider is needed for requesting protected API endpoints. Please provide an implementation of "%s".',
+            CacheItemPoolInterface::class
+        ), 1);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -231,7 +231,7 @@ final class Client implements ClientInterface
      *
      * @param string $key The item key
      *
-     * @return \Psr\Cache\CacheItemInterface the cache item
+     * @return CacheItemInterface the cache item
      */
     public function getCacheItem(string $key)
     {
@@ -243,7 +243,7 @@ final class Client implements ClientInterface
     /**
      * Save a cache item
      *
-     * @param \Psr\Cache\CacheItemInterface $item The item
+     * @param CacheItemInterface $item The item
      */
     public function saveCacheItem(CacheItemInterface $item): void
     {
@@ -253,7 +253,7 @@ final class Client implements ClientInterface
     /**
      * Delete a cache item
      *
-     * @param \Psr\Cache\CacheItemInterface $item The item
+     * @param CacheItemInterface $item The item
      */
     public function deleteCacheItem(CacheItemInterface $item): void
     {
@@ -292,24 +292,24 @@ final class Client implements ClientInterface
      *
      * @return bool true, if a new access token was saved
      */
-    public function authorize(string $grant, array $params = [])
+    public function authorize(string $grant, array $params = []): bool
     {
         if (! isset($params['code'])) {
-            throw new InvalidArgumentException('Argument #2 "$param" must have a "code" value.');
+            throw new InvalidArgumentException(__METHOD__ . '(): Argument #2 "$param" must have a "code" value.');
         }
-
-        $item = $this->getCacheItem('state');
 
         // Check state if present
         if (isset($params['state'])) {
+            $item = $this->getCacheItem('state');
+
             if (! $item->isHit() or $item->get() !== $params['state']) {
                 $this->deleteCacheItem($item);
 
                 throw new InvalidArgumentException('Invalid state');
             }
-        }
 
-        $this->deleteCacheItem($item);
+            $this->deleteCacheItem($item);
+        }
 
         // Try to get an access token (using the authorization code grant)
         $token = $this->oauth2Provider->getAccessToken($grant, [
@@ -579,13 +579,13 @@ final class Client implements ClientInterface
             return;
         }
 
+        $message = 'The server responses with an unknown error.';
+
         try {
             $document = $this->parseResponse($response);
         } catch (Throwable $th) {
-            throw ErrorResponseException::fromResponse($response, 'The server responses with an unknown error.');
+            throw ErrorResponseException::fromResponse($response, $message);
         }
-
-        $message = 'The server responses with an unknown error.';
 
         // Get an error message from the json api body
         if ($document->has('errors.0')) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -23,7 +23,6 @@ namespace Youthweb\Api;
 
 use Art4\JsonApiClient\Accessable;
 use Art4\JsonApiClient\Helper\Parser as JsonApiParser;
-use Cache\Adapter\Void\VoidCachePool;
 use DateInterval;
 use DateTimeImmutable;
 use Exception;
@@ -43,6 +42,7 @@ use Psr\Http\Message\UriFactoryInterface;
 use Throwable;
 use Youthweb\Api\Authentication\Authenticator;
 use Youthweb\Api\Authentication\NativeAuthenticator;
+use Youthweb\Api\Cache\NullCacheItemPool;
 use Youthweb\Api\Exception\ErrorResponseException;
 use Youthweb\Api\Exception\UnauthorizedException;
 use Youthweb\Api\Resource\ResourceInterface;
@@ -198,7 +198,7 @@ final class Client implements ClientInterface
         $this->oauth2Provider = $collaborators['oauth2_provider'];
 
         if (empty($collaborators['cache_provider'])) {
-            $collaborators['cache_provider'] = new VoidCachePool();
+            $collaborators['cache_provider'] = new NullCacheItemPool();
         }
 
         $this->cacheProvider = $collaborators['cache_provider'];
@@ -415,15 +415,6 @@ final class Client implements ClientInterface
         $request = $this->createRequest('POST', $this->getApiUrl() . $path, $data);
 
         return $this->runRequest($request);
-    }
-
-    /**
-     * destructor
-     **/
-    public function __destruct()
-    {
-        // Save deferred items
-        $this->cacheProvider->commit();
     }
 
     /**

--- a/tests/Integration/ClientTest.php
+++ b/tests/Integration/ClientTest.php
@@ -22,16 +22,17 @@ declare(strict_types=1);
 namespace Youthweb\Api\Tests\Integration;
 
 use Youthweb\Api\Client;
+use Youthweb\Api\ClientInterface;
 
 class ClientTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test
      */
-    public function testCreateClientWithoutParameters(): void
+    public function testClientImplementsClientInterface(): void
     {
         $client = new Client();
 
-        $this->assertInstanceOf('Youthweb\Api\ClientInterface', $client);
+        $this->assertInstanceOf(ClientInterface::class, $client);
     }
 }

--- a/tests/Integration/ClientTest.php
+++ b/tests/Integration/ClientTest.php
@@ -21,18 +21,27 @@ declare(strict_types=1);
 
 namespace Youthweb\Api\Tests\Integration;
 
+use LogicException;
+use PHPUnit\Framework\TestCase;
 use Youthweb\Api\Client;
 use Youthweb\Api\ClientInterface;
 
-class ClientTest extends \PHPUnit\Framework\TestCase
+class ClientTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function testClientImplementsClientInterface(): void
     {
         $client = new Client();
 
         $this->assertInstanceOf(ClientInterface::class, $client);
+    }
+
+    public function testAuthorizedHttpRequestsWithoutCacheProviderThrowsException(): void
+    {
+        $client = new Client();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A cache provider is needed for requesting protected API endpoints. Please provide an implementation of "Psr\Cache\CacheItemPoolInterface".');
+
+        $client->get('/endpoint');
     }
 }

--- a/tests/Unit/Cache/NullCacheItemPoolTest.php
+++ b/tests/Unit/Cache/NullCacheItemPoolTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace Youthweb\Api\Tests\Unit\Cache;
 
 use Exception;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -46,11 +47,8 @@ class NullCacheItemPoolTest extends TestCase
 
     public function testGetItemReturnsSameCacheItem(): void
     {
-        $item = $this->createMock(CacheItemInterface::class);
-        $item->method('getKey')->willReturn('name');
-
         $pool = new NullCacheItemPool();
-        $pool->save($item);
+        $item = $pool->getItem('name');
 
         $this->assertSame($item, $pool->getItem('name'));
     }
@@ -111,6 +109,16 @@ class NullCacheItemPoolTest extends TestCase
         $this->expectExceptionMessage('::deleteItems() is not implemented.');
 
         $pool->deleteItems([]);
+    }
+
+    public function testSaveThrowsLogicExcpetion(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A cache provider is needed for requesting protected API endpoints. Please provide an implementation of "Psr\Cache\CacheItemPoolInterface".');
+
+        $pool->save($this->createMock(CacheItemInterface::class));
     }
 
     public function testSaveDeferredIsNotImplemented(): void

--- a/tests/Unit/Cache/NullCacheItemPoolTest.php
+++ b/tests/Unit/Cache/NullCacheItemPoolTest.php
@@ -71,6 +71,21 @@ class NullCacheItemPoolTest extends TestCase
         $pool->getItem('-');
     }
 
+    public function testDeleteItemWithLoadedItemReturnsTrue(): void
+    {
+        $pool = new NullCacheItemPool();
+        $item = $pool->getItem('name');
+
+        $this->assertTrue($pool->deleteItem('name'));
+    }
+
+    public function testDeleteItemWithUnloadedItemReturnsFalse(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->assertFalse($pool->deleteItem('name'));
+    }
+
     public function testGetItemsIsNotImplemented(): void
     {
         $pool = new NullCacheItemPool();

--- a/tests/Unit/Cache/NullCacheItemPoolTest.php
+++ b/tests/Unit/Cache/NullCacheItemPoolTest.php
@@ -25,6 +25,7 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
 use Youthweb\Api\Cache\NullCacheItemPool;
 
 class NullCacheItemPoolTest extends TestCase
@@ -52,6 +53,24 @@ class NullCacheItemPoolTest extends TestCase
         $pool->save($item);
 
         $this->assertSame($item, $pool->getItem('name'));
+    }
+
+    public function testGetItemWithEmptyKeyThrowsInvalidArgumentException(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $pool->getItem('');
+    }
+
+    public function testGetItemWithInvalidKeyThrowsInvalidArgumentException(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $pool->getItem('-');
     }
 
     public function testGetItemsIsNotImplemented(): void

--- a/tests/Unit/Cache/NullCacheItemPoolTest.php
+++ b/tests/Unit/Cache/NullCacheItemPoolTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * PHP Youthweb API is an object-oriented wrapper for PHP of the Youthweb API.
+ * Copyright (C) 2015-2019  Youthweb e.V.  https://youthweb.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Youthweb\Api\Tests\Unit\Cache;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Youthweb\Api\Cache\NullCacheItemPool;
+
+class NullCacheItemPoolTest extends TestCase
+{
+    public function testNullCacheItemPoolImplementsCacheItemPoolInterface(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->assertInstanceOf(CacheItemPoolInterface::class, $pool);
+    }
+
+    public function testGetItemReturnsCacheItemInterface(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->assertInstanceOf(CacheItemInterface::class, $pool->getItem('name'));
+    }
+
+    public function testGetItemReturnsSameCacheItem(): void
+    {
+        $item = $this->createMock(CacheItemInterface::class);
+        $item->method('getKey')->willReturn('name');
+
+        $pool = new NullCacheItemPool();
+        $pool->save($item);
+
+        $this->assertSame($item, $pool->getItem('name'));
+    }
+
+    public function testGetItemsIsNotImplemented(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::getItems() is not implemented.');
+
+        $pool->getItems([]);
+    }
+
+    public function testHasItemIsNotImplemented(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::hasItem() is not implemented.');
+
+        $pool->hasItem('name');
+    }
+
+    public function testClearIsNotImplemented(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::clear() is not implemented.');
+
+        $pool->clear();
+    }
+
+    public function testDeleteItemsIsNotImplemented(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::deleteItems() is not implemented.');
+
+        $pool->deleteItems([]);
+    }
+
+    public function testSaveDeferredIsNotImplemented(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::saveDeferred() is not implemented.');
+
+        $pool->saveDeferred($this->createMock(CacheItemInterface::class));
+    }
+
+    public function testCommitIsNotImplemented(): void
+    {
+        $pool = new NullCacheItemPool();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::commit() is not implemented.');
+
+        $pool->commit();
+    }
+}

--- a/tests/Unit/Cache/NullCacheItemTest.php
+++ b/tests/Unit/Cache/NullCacheItemTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * PHP Youthweb API is an object-oriented wrapper for PHP of the Youthweb API.
+ * Copyright (C) 2015-2019  Youthweb e.V.  https://youthweb.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Youthweb\Api\Tests\Unit\Cache;
+
+use DateInterval;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Youthweb\Api\Cache\NullCacheItem;
+
+class NullCacheItemTest extends TestCase
+{
+    public function testGetKeyReturnsKey(): void
+    {
+        $item = new NullCacheItem('name');
+
+        $this->assertSame('name', $item->getKey());
+    }
+
+    public function testGetWithoutValueReturnsNull(): void
+    {
+        $item = new NullCacheItem('name');
+
+        $this->assertSame(null, $item->get());
+    }
+
+    public function testGetWithValueReturnsValue(): void
+    {
+        $value = new stdClass();
+
+        $item = new NullCacheItem('name');
+        $item->set($value);
+
+        $this->assertSame($value, $item->get());
+    }
+
+    public function testIsHitWithoutValueReturnsFalse(): void
+    {
+        $item = new NullCacheItem('name');
+
+        $this->assertSame(false, $item->isHit());
+    }
+
+    public function testIsHitWithValueReturnsTrue(): void
+    {
+        $value = new stdClass();
+
+        $item = new NullCacheItem('name');
+        $item->set($value);
+
+        $this->assertSame(true, $item->isHit());
+    }
+
+    public function testSetReturnsSelf(): void
+    {
+        $value = new stdClass();
+
+        $item = new NullCacheItem('name');
+
+        $this->assertSame($item, $item->set($value));
+    }
+
+    public function testExpiresAtWithDateTimeReturnsSelf(): void
+    {
+        $item = new NullCacheItem('name');
+
+        $this->assertSame($item, $item->expiresAt(new DateTimeImmutable()));
+    }
+
+    public function testExpiresAtWithNullReturnsSelf(): void
+    {
+        $item = new NullCacheItem('name');
+
+        $this->assertSame($item, $item->expiresAt(null));
+    }
+
+    public function testExpiresAfterWithIntegerReturnsSelf(): void
+    {
+        $item = new NullCacheItem('name');
+
+        $this->assertSame($item, $item->expiresAfter(1));
+    }
+
+    public function testExpiresAfterWithDateIntervalReturnsSelf(): void
+    {
+        $item = new NullCacheItem('name');
+
+        $this->assertSame($item, $item->expiresAfter(new DateInterval('PT1S')));
+    }
+
+    public function testExpiresAfterWithNullReturnsSelf(): void
+    {
+        $item = new NullCacheItem('name');
+
+        $this->assertSame($item, $item->expiresAfter(null));
+    }
+}

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -152,7 +152,9 @@ class ClientTest extends TestCase
 
         $client = $this->createClient(
             [],
-            ['resource_factory' => $resource_factory]
+            [
+                'resource_factory' => $resource_factory,
+            ]
         );
 
         $this->assertSame($resource, $client->getResource('users'));
@@ -241,8 +243,6 @@ class ClientTest extends TestCase
                 ['php_youthweb_api.access_token', $cache_item_access],
             ]));
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
-
         $client = $this->createClient(
             [
                 'client_id'     => 'client_id',
@@ -250,7 +250,6 @@ class ClientTest extends TestCase
                 'redirect_url'  => 'https://example.org/callback',
             ],
             [
-                'http_client' => $httpClient,
                 'cache_provider' => $cache_provider,
                 'oauth2_provider' => $oauth2Provider,
             ]
@@ -307,8 +306,6 @@ class ClientTest extends TestCase
                 ['php_youthweb_api.state', $cache_item_state],
             ]));
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
-
         $client = $this->createClient(
             [
                 'client_id'     => 'client_id',
@@ -316,7 +313,6 @@ class ClientTest extends TestCase
                 'redirect_url'  => 'https://example.org/callback',
             ],
             [
-                'http_client' => $httpClient,
                 'cache_provider' => $cache_provider,
                 'oauth2_provider' => $oauth2Provider,
             ]
@@ -352,8 +348,6 @@ class ClientTest extends TestCase
                 ['php_youthweb_api.state', $cache_item_state],
             ]));
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
-
         $client = $this->createClient(
             [
                 'client_id'     => 'client_id',
@@ -361,7 +355,6 @@ class ClientTest extends TestCase
                 'redirect_url'  => 'https://example.org/callback',
             ],
             [
-                'http_client' => $httpClient,
                 'cache_provider' => $cache_provider,
             ]
         );
@@ -396,8 +389,6 @@ class ClientTest extends TestCase
                 ['php_youthweb_api.access_token', $cache_item_state],
             ]));
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
-
         $client = $this->createClient(
             [
                 'client_id'     => 'client_id',
@@ -405,7 +396,6 @@ class ClientTest extends TestCase
                 'redirect_url'  => 'https://example.org/callback',
             ],
             [
-                'http_client' => $httpClient,
                 'cache_provider' => $cache_provider,
             ]
         );
@@ -440,8 +430,6 @@ class ClientTest extends TestCase
                 ['php_youthweb_api.state', $cache_item_state],
             ]));
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
-
         $client = $this->createClient(
             [
                 'client_id'     => 'client_id',
@@ -449,7 +437,6 @@ class ClientTest extends TestCase
                 'redirect_url'  => 'https://example.org/callback',
             ],
             [
-                'http_client' => $httpClient,
                 'cache_provider' => $cache_provider,
             ]
         );
@@ -626,16 +613,10 @@ class ClientTest extends TestCase
                 ['php_youthweb_api.state', $cache_item_state],
             ]));
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
-
-        $resource_factory = $this->createMock(ResourceFactoryInterface::class);
-
         $client = $this->createClient(
             [],
             [
-                'http_client' => $httpClient,
                 'cache_provider' => $cache_provider,
-                'resource_factory' => $resource_factory,
             ]
         );
 
@@ -676,7 +657,7 @@ class ClientTest extends TestCase
 
         // We cannot create a mock for ClientExceptionInterface (or \Throwable)
         // @link https://github.com/sebastianbergmann/phpunit/issues/4458
-        $exception = new class() extends Exception implements ClientExceptionInterface {};
+        $exception = new class () extends Exception implements ClientExceptionInterface {};
 
         $httpClient = $this->createMock(HttpClientInterface::class);
         $httpClient->expects($this->once())

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -219,16 +219,8 @@ class ClientTest extends TestCase
             ->method('getExpires')
             ->willReturn(1234567890);
 
-        $cache_item_state = $this->createMock(CacheItemInterface::class);
-        $cache_item_state->expects($this->any())
-            ->method('isHit')
-            ->willReturn(false);
-
-        $cache_item_state->method('getKey')
-            ->willReturn('');
-
         $cache_item_access = $this->createMock(CacheItemInterface::class);
-        $cache_item_access->expects($this->any())
+        $cache_item_access->expects($this->never())
             ->method('isHit')
             ->willReturn(false);
 
@@ -243,11 +235,10 @@ class ClientTest extends TestCase
             ->willReturn($access_token);
 
         $cache_provider = $this->createMock(CacheItemPoolInterface::class);
-        $cache_provider->expects($this->exactly(2))
+        $cache_provider->expects($this->exactly(1))
             ->method('getItem')
             ->will($this->returnValueMap([
                 ['php_youthweb_api.access_token', $cache_item_access],
-                ['php_youthweb_api.state', $cache_item_state],
             ]));
 
         $httpClient = $this->createMock(HttpClientInterface::class);
@@ -1056,11 +1047,8 @@ class ClientTest extends TestCase
 
         $cache_provider = $this->createMock(CacheItemPoolInterface::class);
         $cache_provider->expects($this->exactly(1))
-            ->method('saveDeferred')
+            ->method('save')
             ->with($cache_item);
-
-        $cache_provider->expects($this->exactly(2))
-            ->method('commit');
 
         $client = $this->createClient(
             [],

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -227,8 +227,7 @@ class ClientTest extends TestCase
             ->willReturn(false);
 
         $cache_item_access->expects($this->once())
-            ->method('set')
-            ->willReturn('access_token');
+            ->method('set');
 
         $oauth2Provider = $this->createMock(Authenticator::class);
         $oauth2Provider->expects($this->once())
@@ -289,8 +288,7 @@ class ClientTest extends TestCase
             ->willReturn(false);
 
         $cache_item_access->expects($this->once())
-            ->method('set')
-            ->willReturn('access_token');
+            ->method('set');
 
         $oauth2Provider = $this->createMock(Authenticator::class);
         $oauth2Provider->expects($this->once())


### PR DESCRIPTION
This will remove the dependency to external VoidCache library and allows us to trigger errors, if no cache pool was provided.