### PR TITLE
Allow using PSR-18 Client and PSR-17 RequestFactory in OAuth2 client

### DIFF
--- a/src/Authentication/Psr17RequestFactoryAdapter.php
+++ b/src/Authentication/Psr17RequestFactoryAdapter.php
@@ -88,11 +88,11 @@ final class Psr17RequestFactoryAdapter extends RequestFactory
                 $request = $request->withBody(
                     $this->psr17StreamFactory->createStream($body)
                 );
-            } else if (is_resource($body)) {
+            } elseif (is_resource($body)) {
                 $request = $request->withBody(
                     $this->psr17StreamFactory->createStreamFromResource($body)
                 );
-            } else if ($body instanceof StreamInterface) {
+            } elseif ($body instanceof StreamInterface) {
                 $request = $request->withBody($body);
             }
         }

--- a/src/Authentication/Psr17RequestFactoryAdapter.php
+++ b/src/Authentication/Psr17RequestFactoryAdapter.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * PHP Youthweb API is an object-oriented wrapper for PHP of the Youthweb API.
+ * Copyright (C) 2015-2019  Youthweb e.V.  https://youthweb.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Youthweb\Api\Authentication;
+
+use League\OAuth2\Client\Tool\RequestFactory;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
+
+/**
+ * Adapter for PSR-17 Request factory to implement league/oauth2-client RequestFactory
+ *
+ * @internal
+ */
+final class Psr17RequestFactoryAdapter extends RequestFactory
+{
+    public static function createFromPsr17(
+        RequestFactoryInterface $psr17RequestFactory,
+        StreamFactoryInterface $psr17StreamFactory,
+        UriFactoryInterface $psr17UriFactory,
+    ): self {
+        $factory = new self();
+        $factory->psr17RequestFactory = $psr17RequestFactory;
+        $factory->psr17StreamFactory = $psr17StreamFactory;
+        $factory->psr17UriFactory = $psr17UriFactory;
+
+        return $factory;
+    }
+
+    private RequestFactoryInterface $psr17RequestFactory;
+
+    private StreamFactoryInterface $psr17StreamFactory;
+
+    private UriFactoryInterface $psr17UriFactory;
+
+    /**
+     * Creates a PSR-7 Request instance.
+     *
+     * @param  null|string $method HTTP method for the request.
+     * @param  null|string $uri URI for the request.
+     * @param  array $headers Headers for the message.
+     * @param  string|resource|StreamInterface $body Message body.
+     * @param  string $version HTTP protocol version.
+     *
+     * @return RequestInterface
+     */
+    public function getRequest(
+        $method,
+        $uri,
+        array $headers = [],
+        $body = null,
+        $version = '1.1'
+    ) {
+        // return new Request($method, $uri, $headers, $body, $version);
+        $request = $this->psr17RequestFactory->createRequest(
+            strval($method),
+            $this->psr17UriFactory->createUri(strval($uri)),
+        );
+        $request = $request->withProtocolVersion($version);
+
+        foreach ($headers as $key => $value) {
+            $request = $request->withAddedHeader($key, $value);
+        }
+
+        if ($body !== '' && $body !== null) {
+            if (is_string($body)) {
+                $request = $request->withBody(
+                    $this->psr17StreamFactory->createStream($body)
+                );
+            } else if (is_resource($body)) {
+                $request = $request->withBody(
+                    $this->psr17StreamFactory->createStreamFromResource($body)
+                );
+            }
+        }
+
+        return $request;
+    }
+}

--- a/src/Authentication/Psr17RequestFactoryAdapter.php
+++ b/src/Authentication/Psr17RequestFactoryAdapter.php
@@ -25,6 +25,7 @@ use League\OAuth2\Client\Tool\RequestFactory;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriFactoryInterface;
 
 /**
@@ -91,6 +92,8 @@ final class Psr17RequestFactoryAdapter extends RequestFactory
                 $request = $request->withBody(
                     $this->psr17StreamFactory->createStreamFromResource($body)
                 );
+            } else if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
             }
         }
 

--- a/src/Authentication/Psr18GuzzleAdapter.php
+++ b/src/Authentication/Psr18GuzzleAdapter.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * PHP Youthweb API is an object-oriented wrapper for PHP of the Youthweb API.
+ * Copyright (C) 2015-2019  Youthweb e.V.  https://youthweb.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Youthweb\Api\Authentication;
+
+use Exception;
+use GuzzleHttp\ClientInterface as GuzzleHttpClientInterface;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Adapter for PSR-18 clients to implement Guzzle ClientInterface
+ *
+ * @internal
+ */
+final class Psr18GuzzleAdapter implements GuzzleHttpClientInterface
+{
+    public function __construct(
+        private ClientInterface $client
+    ) {
+    }
+
+    public function send(RequestInterface $request, array $options = []): ResponseInterface
+    {
+        return $this->client->sendRequest($request);
+    }
+
+    public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+
+    public function request(string $method, $uri, array $options = []): ResponseInterface
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+
+    public function requestAsync(string $method, $uri, array $options = []): PromiseInterface
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+
+    public function getConfig(?string $option = null)
+    {
+        throw new Exception(__METHOD__ . '() is not implemented.', 1);
+    }
+}

--- a/src/Authentication/Psr18GuzzleAdapter.php
+++ b/src/Authentication/Psr18GuzzleAdapter.php
@@ -60,7 +60,7 @@ final class Psr18GuzzleAdapter implements GuzzleHttpClientInterface
         throw new Exception(__METHOD__ . '() is not implemented.', 1);
     }
 
-    public function getConfig(?string $option = null)
+    public function getConfig(?string $option = null): void
     {
         throw new Exception(__METHOD__ . '() is not implemented.', 1);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -26,7 +26,6 @@ use Art4\JsonApiClient\Helper\Parser as JsonApiParser;
 use DateInterval;
 use DateTimeImmutable;
 use Exception;
-use GuzzleHttp\Psr7\HttpFactory;
 use InvalidArgumentException;
 use League\OAuth2\Client\Token\AccessTokenInterface;
 use Psr\Cache\CacheItemInterface;

--- a/tests/Unit/Authentication/Psr17RequestFactoryAdapterTest.php
+++ b/tests/Unit/Authentication/Psr17RequestFactoryAdapterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * PHP Youthweb API is an object-oriented wrapper for PHP of the Youthweb API.
+ * Copyright (C) 2015-2019  Youthweb e.V.  https://youthweb.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Youthweb\Api\Tests\Unit\Authentication;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
+use Youthweb\Api\Authentication\Psr17RequestFactoryAdapter;
+
+class Psr17RequestFactoryAdapterTest extends TestCase
+{
+    public function testGetRequestReturnsRequestInterface(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('withProtocolVersion')->willReturn($request);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $adapter = Psr17RequestFactoryAdapter::createFromPsr17(
+            $requestFactory,
+            $this->createMock(StreamFactoryInterface::class),
+            $this->createMock(UriFactoryInterface::class),
+        );
+
+        $this->assertInstanceOf(RequestInterface::class, $adapter->getRequest('GET', ''));
+    }
+}

--- a/tests/Unit/Authentication/Psr17RequestFactoryAdapterTest.php
+++ b/tests/Unit/Authentication/Psr17RequestFactoryAdapterTest.php
@@ -82,6 +82,7 @@ class Psr17RequestFactoryAdapterTest extends TestCase
     {
         $streamFactory = $this->createMock(StreamFactoryInterface::class);
         $streamFactory->expects($this->never())->method('createStream');
+        $streamFactory->expects($this->never())->method('createStreamFromResource');
 
         $request = $this->createMock(RequestInterface::class);
         $request->method('withProtocolVersion')->willReturn($request);
@@ -97,7 +98,106 @@ class Psr17RequestFactoryAdapterTest extends TestCase
 
         $this->assertInstanceOf(
             RequestInterface::class,
-            $adapter->getRequest('GET', 'https://example.com', []),
+            $adapter->getRequest('POST', 'https://example.com', [], null),
+        );
+    }
+
+    public function testGetRequestWithEmptyStringCallsThePsr17StreamFactoryCorrectly(): void
+    {
+        $streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $streamFactory->expects($this->never())->method('createStream');
+        $streamFactory->expects($this->never())->method('createStreamFromResource');
+
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('withProtocolVersion')->willReturn($request);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $adapter = Psr17RequestFactoryAdapter::createFromPsr17(
+            $requestFactory,
+            $streamFactory,
+            $this->createMock(UriFactoryInterface::class),
+        );
+
+        $this->assertInstanceOf(
+            RequestInterface::class,
+            $adapter->getRequest('POST', 'https://example.com', [], ''),
+        );
+    }
+
+    public function testGetRequestWithStringCallsThePsr17StreamFactoryCorrectly(): void
+    {
+        $streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $streamFactory->expects($this->once())->method('createStream')->willReturn($this->createMock(StreamInterface::class));
+        $streamFactory->expects($this->never())->method('createStreamFromResource');
+
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('withProtocolVersion')->willReturn($request);
+        $request->method('withBody')->willReturn($request);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $adapter = Psr17RequestFactoryAdapter::createFromPsr17(
+            $requestFactory,
+            $streamFactory,
+            $this->createMock(UriFactoryInterface::class),
+        );
+
+        $this->assertInstanceOf(
+            RequestInterface::class,
+            $adapter->getRequest('POST', 'https://example.com', [], '{}'),
+        );
+    }
+
+    public function testGetRequestWithResourceCallsThePsr17StreamFactoryCorrectly(): void
+    {
+        $streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $streamFactory->expects($this->never())->method('createStream');
+        $streamFactory->expects($this->once())->method('createStreamFromResource')->willReturn($this->createMock(StreamInterface::class));
+
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('withProtocolVersion')->willReturn($request);
+        $request->method('withBody')->willReturn($request);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $adapter = Psr17RequestFactoryAdapter::createFromPsr17(
+            $requestFactory,
+            $streamFactory,
+            $this->createMock(UriFactoryInterface::class),
+        );
+
+        $this->assertInstanceOf(
+            RequestInterface::class,
+            $adapter->getRequest('POST', 'https://example.com', [], fopen(__FILE__, 'r')),
+        );
+    }
+
+    public function testGetRequestWithStreamCallsThePsr17StreamFactoryCorrectly(): void
+    {
+        $streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $streamFactory->expects($this->never())->method('createStream');
+        $streamFactory->expects($this->never())->method('createStreamFromResource');
+
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('withProtocolVersion')->willReturn($request);
+        $request->method('withBody')->willReturn($request);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $adapter = Psr17RequestFactoryAdapter::createFromPsr17(
+            $requestFactory,
+            $streamFactory,
+            $this->createMock(UriFactoryInterface::class),
+        );
+
+        $this->assertInstanceOf(
+            RequestInterface::class,
+            $adapter->getRequest('POST', 'https://example.com', [], $this->createMock(StreamInterface::class)),
         );
     }
 }

--- a/tests/Unit/Authentication/Psr18GuzzleAdapterTest.php
+++ b/tests/Unit/Authentication/Psr18GuzzleAdapterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * PHP Youthweb API is an object-oriented wrapper for PHP of the Youthweb API.
+ * Copyright (C) 2015-2019  Youthweb e.V.  https://youthweb.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Youthweb\Api\Tests\Unit\Authentication;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Youthweb\Api\Authentication\Psr18GuzzleAdapter;
+
+class Psr18GuzzleAdapterTest extends TestCase
+{
+    public function testSendIsNotImplemented(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())->method('sendRequest')->with($request)->willReturn(
+            $this->createMock(ResponseInterface::class)
+        );
+
+        $adapter = new Psr18GuzzleAdapter($client);
+
+        $adapter->send($request);
+    }
+
+    public function testSendAsyncIsNotImplemented(): void
+    {
+        $adapter = new Psr18GuzzleAdapter($this->createMock(ClientInterface::class));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::sendAsync() is not implemented.');
+
+        $adapter->sendAsync($this->createMock(RequestInterface::class));
+    }
+
+    public function testRequestIsNotImplemented(): void
+    {
+        $adapter = new Psr18GuzzleAdapter($this->createMock(ClientInterface::class));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::request() is not implemented.');
+
+        $adapter->request('GET', '');
+    }
+
+    public function testRequestAsyncIsNotImplemented(): void
+    {
+        $adapter = new Psr18GuzzleAdapter($this->createMock(ClientInterface::class));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::requestAsync() is not implemented.');
+
+        $adapter->requestAsync('GET', '');
+    }
+
+    public function testGetConfigIsNotImplemented(): void
+    {
+        $adapter = new Psr18GuzzleAdapter($this->createMock(ClientInterface::class));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('::getConfig() is not implemented.');
+
+        $adapter->getConfig();
+    }
+}


### PR DESCRIPTION
As long as league/oauth2-client does not support PSR-18 client and PSR-17 request factory, we need an adapter.

See https://github.com/thephpleague/oauth2-client/issues/685.